### PR TITLE
Count 'z' as five characters during decoding

### DIFF
--- a/src/main/java/io/github/jacksonbailey/ascii85/Ascii85.java
+++ b/src/main/java/io/github/jacksonbailey/ascii85/Ascii85.java
@@ -92,8 +92,10 @@ public class Ascii85 {
       throw new IllegalArgumentException("You must provide a non-zero length input");
     }
     // By using five ASCII characters to represent four bytes of binary data the encoded size ¹⁄₄ is
-    // larger than the original
-    ByteBuffer bytebuff = ByteBuffer.allocate((chars.length() * 4 / 5));
+    // larger than the original. Each 'z' counts as five chars due to compression while encoding.
+    int uncompressedSize = chars.chars().map(c -> c == 'z' ? 5 : 1).sum();
+    int bufferSize = (uncompressedSize * 4 / 5);
+    ByteBuffer bytebuff = ByteBuffer.allocate(bufferSize);
     // 1. Whitespace characters may occur anywhere to accommodate line length limitations. So lets
     // strip it.
     chars = REMOVE_WHITESPACE.matcher(chars).replaceAll("");

--- a/src/test/java/io/github/jacksonbailey/ascii85/Ascii85Test.java
+++ b/src/test/java/io/github/jacksonbailey/ascii85/Ascii85Test.java
@@ -55,6 +55,24 @@ public class Ascii85Test {
   }
 
   @Test
+  public void allZeroChunkEncode() {
+    byte[] input = new byte[] {0x0, 0x0, 0x0, 0x0};
+
+    String output = Ascii85.encode(input);
+
+    assertEquals("z", output);
+  }
+
+  @Test
+  public void allZeroChunkDecode() {
+    String input = "z";
+
+    byte[] output = Ascii85.decode(input);
+
+    assertArrayEquals(new byte[] {0x0, 0x0, 0x0, 0x0}, output);
+  }
+
+  @Test
   public void decodeShouldIgnoreNewLineCharacter() {
     String encodedString =
         "9jqo^BlbD-BleB1DJ+*+F(f,q/0JhKF<GL>Cj@.4Gp$d7F!,L7@<6@)/0JDEF<G%<+EV:2F!,\n"


### PR DESCRIPTION
When encoding if there is a chunk of all zeroes instead of being encoded
as "`!!!!!`" it is encoded as "`z`" as a lightweight form of
compression. This means that when decoding any "`z`" in the input needs
to be count as five characters (instead of one) when determining what
the length of the final output will be.

Since this was being counted wrong there was an overflow error when `z`
was being decoded because the buffer was smaller than it needed to be.

Fixes #1